### PR TITLE
Add standalone tasks management server package with queue-based workflow API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ is implemented with an MCP SDK:
 These servers aim to demonstrate MCP features and the official SDKs.
 
 - **[Deep Thinking](src/deep-thinking)** - Dynamic and reflective
-  problem-solving through thought sequences
+  problem-solving through thought sequences.
+- **[Tasks](src/tasks)** - Self guided task planning, management, execution and
+  completion.
 
 ## 🚀 Getting Started
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "src/tasks": {
       "name": "@wemake-ai/mcpserver-tasks",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "bin": {
         "mcpserver-tasks": "dist/index.js",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "src/deep-thinking": {
       "name": "@wemake-ai/mcpserver-deep-thinking",
-      "version": "1.0.1",
+      "version": "0.0.1",
       "bin": {
         "mcpserver-deep-thinking": "dist/index.js",
       },
@@ -31,6 +31,26 @@
         "@types/yargs": "^17.0.33",
         "shx": "^0.4.0",
         "typescript": "^5.8.3",
+      },
+    },
+    "src/tasks": {
+      "name": "@wemake-ai/mcpserver-tasks",
+      "version": "0.0.5",
+      "bin": {
+        "mcpserver-tasks": "dist/index.js",
+      },
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "0.5.0",
+        "chalk": "^5.3.0",
+        "glob": "^10.3.10",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.5",
+      },
+      "devDependencies": {
+        "@types/json-schema": "^7.0.15",
+        "@types/node": "^20.11.0",
+        "shx": "^0.3.4",
+        "typescript": "^5.3.3",
       },
     },
   },
@@ -61,6 +81,8 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.17.0", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
@@ -68,6 +90,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
 
@@ -112,6 +136,8 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.38.0", "", { "dependencies": { "@typescript-eslint/types": "8.38.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g=="],
 
     "@wemake-ai/mcpserver-deep-thinking": ["@wemake-ai/mcpserver-deep-thinking@workspace:src/deep-thinking"],
+
+    "@wemake-ai/mcpserver-tasks": ["@wemake-ai/mcpserver-tasks@workspace:src/tasks"],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -191,6 +217,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
@@ -261,9 +289,13 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -276,6 +308,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@4.1.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w=="],
+
+    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -301,6 +335,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "interpret": ["interpret@1.4.0", "", {}, "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="],
@@ -317,6 +353,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
@@ -328,6 +366,8 @@
     "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
@@ -346,6 +386,8 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "markdownlint": ["markdownlint@0.38.0", "", { "dependencies": { "micromark": "4.0.2", "micromark-core-commonmark": "2.0.3", "micromark-extension-directive": "4.0.0", "micromark-extension-gfm-autolink-literal": "2.1.0", "micromark-extension-gfm-footnote": "2.1.0", "micromark-extension-gfm-table": "2.1.1", "micromark-extension-math": "3.1.0", "micromark-util-types": "2.0.2" } }, "sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ=="],
 
@@ -417,6 +459,8 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -443,6 +487,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -451,9 +497,13 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
@@ -519,13 +569,17 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-eof": ["strip-eof@1.0.0", "", {}, "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q=="],
 
@@ -561,6 +615,8 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
 
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -581,7 +637,17 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@wemake-ai/mcpserver-tasks/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@0.5.0", "", { "dependencies": { "content-type": "^1.0.5", "raw-body": "^3.0.0", "zod": "^3.23.8" } }, "sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ=="],
+
+    "@wemake-ai/mcpserver-tasks/@types/node": ["@types/node@20.19.9", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw=="],
+
+    "@wemake-ai/mcpserver-tasks/shx": ["shx@0.3.4", "", { "dependencies": { "minimist": "^1.2.3", "shelljs": "^0.8.5" }, "bin": { "shx": "lib/cli.js" } }, "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g=="],
 
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -589,15 +655,37 @@
 
     "execa/cross-spawn": ["cross-spawn@6.0.6", "", { "dependencies": { "nice-try": "^1.0.4", "path-key": "^2.0.1", "semver": "^5.5.0", "shebang-command": "^1.2.0", "which": "^1.2.9" } }, "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw=="],
 
+    "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
 
     "npm-run-path/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@wemake-ai/mcpserver-tasks/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@wemake-ai/mcpserver-tasks/shx/shelljs": ["shelljs@0.8.5", "", { "dependencies": { "glob": "^7.0.0", "interpret": "^1.0.0", "rechoir": "^0.6.2" }, "bin": { "shjs": "bin/shjs" } }, "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow=="],
 
     "execa/cross-spawn/path-key": ["path-key@2.0.1", "", {}, "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="],
 
@@ -606,6 +694,16 @@
     "execa/cross-spawn/shebang-command": ["shebang-command@1.2.0", "", { "dependencies": { "shebang-regex": "^1.0.0" } }, "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg=="],
 
     "execa/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@wemake-ai/mcpserver-tasks/shx/shelljs/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "execa/cross-spawn/shebang-command/shebang-regex": ["shebang-regex@1.0.0", "", {}, "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcp",
-  "version": "25.1.3",
+  "version": "25.2.0",
   "author": "WeMake (https://wemake.cx)",
   "devDependencies": {
     "@types/bun": "latest",
@@ -25,10 +25,13 @@
   "private": true,
   "scripts": {
     "deep-thinking:build": "bun run --cwd=src/deep-thinking build",
-    "deep-thinking:publish": "bun run --cwd=src/deep-thinking publish",
+    "deep-thinking:publish": "bun publish --access=public --cwd=src/deep-thinking",
+    "tasks:build": "bun run --cwd=src/tasks build",
+    "tasks:publish": "bun publish --access=public --cwd=src/tasks",
     "format": "bun prettier && bun lint --fix",
     "prettier": "bunx prettier --write .",
-    "lint": "bunx eslint . --ext .ts,.tsx"
+    "lint": "bunx eslint . --ext .ts,.tsx",
+    "check": "tsc --noEmit"
   },
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deep-thinking:publish": "bun publish --access=public --cwd=src/deep-thinking",
     "tasks:build": "bun run --cwd=src/tasks build",
     "tasks:publish": "bun publish --access=public --cwd=src/tasks",
-    "format": "bun prettier && bun lint --fix",
+    "format": "bunx prettier --write . && bun lint --fix",
     "prettier": "bunx prettier --write .",
     "lint": "bunx eslint . --ext .ts,.tsx",
     "check": "tsc --noEmit"

--- a/src/deep-thinking/package.json
+++ b/src/deep-thinking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcpserver-deep-thinking",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "description": "MCP server for deep thinking and problem solving",
   "license": "MIT",
   "author": "WeMake (https://wemake.cx)",
@@ -16,8 +16,7 @@
   "scripts": {
     "build": "bun build --target=bun --outfile=dist/index.js index.ts",
     "prepare": "bun run build",
-    "watch": "tsc --watch",
-    "publish": "bun publish --access public"
+    "watch": "tsc --watch"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.0",

--- a/src/tasks/README.md
+++ b/src/tasks/README.md
@@ -1,0 +1,50 @@
+# Tasks MCP Server
+
+Model Context Protocol server for Task Management. This allows Trae IDE to
+manage and execute tasks in a queue-based system.
+
+## Configuration
+
+### Trae IDE
+
+Add this MCP via "Add Manually":
+
+#### bunx
+
+```json
+{
+  "mcpServers": {
+    "Tasks": {
+      "command": "bunx",
+      "args": ["-y", "@wemake-ai/mcpserver-tasks"],
+      "env": {
+        "TASKS_FILE_PATH": "~/project/.wemake-ai/tasks.json"
+      }
+    }
+  }
+}
+```
+
+## Available Operations
+
+Tasks supports two main phases of operation:
+
+### Planning Phase
+
+- Accepts a task list (array of strings) from the user
+- Stores tasks internally as a queue
+- Returns an execution plan (task overview, task ID, current queue status)
+
+### Execution Phase
+
+- Returns the next task from the queue when requested
+- Provides feedback mechanism for task completion
+- Removes completed tasks from the queue
+- Prepares the next task for execution
+
+### Parameters
+
+- `action`: "plan" | "execute" | "complete"
+- `tasks`: Array of task strings (required for "plan" action)
+- `taskId`: Task identifier (required for "complete" action)
+- `getNext`: Boolean flag to request next task (for "execute" action)

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,0 +1,1417 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  Tool
+} from "@modelcontextprotocol/sdk/types.js";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { z } from "zod";
+
+const DEFAULT_PATH = path.join(os.homedir(), ".wemake-ai", "tasks.json");
+const TASK_FILE_PATH = process.env.TASKS_FILE_PATH || DEFAULT_PATH;
+
+interface Task {
+  id: string;
+  title: string;
+  description: string;
+  done: boolean;
+  approved: boolean;
+  completedDetails: string;
+}
+
+interface RequestEntry {
+  requestId: string;
+  originalRequest: string;
+  splitDetails: string;
+  tasks: Task[];
+  completed: boolean; // marked true after all tasks done and request completion approved
+}
+
+interface TasksFile {
+  requests: RequestEntry[];
+}
+
+// Zod Schemas
+const RequestPlanningSchema = z.object({
+  originalRequest: z.string(),
+  splitDetails: z.string().optional(),
+  tasks: z.array(
+    z.object({
+      title: z.string(),
+      description: z.string()
+    })
+  )
+});
+
+const GetNextTaskSchema = z.object({
+  requestId: z.string()
+});
+
+const MarkTaskDoneSchema = z.object({
+  requestId: z.string(),
+  taskId: z.string(),
+  completedDetails: z.string().optional()
+});
+
+const ApproveTaskCompletionSchema = z.object({
+  requestId: z.string(),
+  taskId: z.string()
+});
+
+const ApproveRequestCompletionSchema = z.object({
+  requestId: z.string()
+});
+
+const OpenTaskDetailsSchema = z.object({
+  taskId: z.string()
+});
+
+const ListRequestsSchema = z.object({});
+
+const AddTasksToRequestSchema = z.object({
+  requestId: z.string(),
+  tasks: z.array(
+    z.object({
+      title: z.string(),
+      description: z.string()
+    })
+  )
+});
+
+const UpdateTaskSchema = z.object({
+  requestId: z.string(),
+  taskId: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional()
+});
+
+const DeleteTaskSchema = z.object({
+  requestId: z.string(),
+  taskId: z.string()
+});
+
+// Tools with enriched English descriptions
+
+const PLANNING_TOOL: Tool = {
+  name: "planning",
+  description: `Use planning to initiate a new task workflow.
+
+MANDATORY PARAMETERS:
+- originalRequest (string): The complete, unmodified user request
+- tasks (array): List of task objects, each containing:
+  - title (string): Concise task identifier (max 50 characters)
+  - description (string): Detailed task specification including success criteria
+
+OPTIONAL PARAMETERS:
+- splitDetails (string): Additional context explaining the task decomposition rationale
+
+EXECUTION PROTOCOL:
+
+1. REQUEST ANALYSIS
+   - Parse the user's original request comprehensively
+   - Identify ALL discrete, actionable components
+   - Ensure no implicit requirements are overlooked
+
+2. TASK DECOMPOSITION
+   - Create atomic tasks that can be independently executed
+   - Each task MUST have clear completion criteria
+   - Tasks should follow logical dependency order
+   - Avoid task overlap or redundancy
+
+3. WORKFLOW INITIALIZATION
+   Upon successful execution, the system will:
+   - Assign a unique requestId
+   - Generate taskIds for each task
+   - Display a progress table showing all tasks
+   - Return confirmation that tasks are registered
+
+CRITICAL WORKFLOW RULES:
+- After using planning, you MUST immediately call get_next_task to retrieve the first task
+- NEVER proceed to execute tasks without first retrieving them via get_next_task
+- The workflow enforces a strict approval cycle: Plan → Execute → Mark Done → Await Approval → Next Task
+- User approval is MANDATORY after each task completion before proceeding
+
+OUTPUT STRUCTURE:
+The tool returns a JSON response containing:
+- status: "planned"
+- requestId: Unique identifier for this request
+- totalTasks: Number of tasks created
+- tasks: Array of task objects with ids
+- message: Confirmation with progress table
+
+CONSTRAINT: You MUST NOT attempt to execute any tasks immediately after planning. The next required action is ALWAYS to call get_next_task.`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      originalRequest: { type: "string" },
+      splitDetails: { type: "string" },
+      tasks: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            description: { type: "string" }
+          },
+          required: ["title", "description"]
+        }
+      }
+    },
+    required: ["originalRequest", "tasks"]
+  }
+};
+
+const GET_NEXT_TASK_TOOL: Tool = {
+  name: "get_next_task",
+  description: `Use get_next_task to retrieve the next pending task for execution.
+
+MANDATORY PARAMETERS:
+- requestId (string): The unique identifier of the active request
+
+EXECUTION LOGIC:
+
+1. TASK RETRIEVAL PROTOCOL
+   The tool will return one of these states:
+   
+   a) "next_task": A pending task is available
+      - Returns task details (id, title, description)
+      - Displays current progress table
+      - Task is ready for execution
+   
+   b) "all_tasks_done": All tasks completed but await final approval
+      - No more tasks to execute
+      - Request completion approval required
+      - Progress table shows all tasks done
+   
+   c) "already_completed": Request was previously finalized
+      - No action possible
+      - Request is archived
+   
+   d) "error": Invalid requestId provided
+
+2. CRITICAL APPROVAL ENFORCEMENT
+   
+   CONSTRAINT 1: After calling mark_task_done, you MUST NOT call get_next_task again until the user explicitly approves via approve_task_completion
+   
+   CONSTRAINT 2: If the same task is returned repeatedly, it indicates the previous task awaits approval - DO NOT proceed
+   
+   CONSTRAINT 3: When "all_tasks_done" status is returned:
+   - DO NOT create new requests
+   - DO NOT attempt any new actions
+   - WAIT for user to call approve_request_completion
+
+3. PROGRESS MONITORING
+   Each response includes a comprehensive progress table showing:
+   - Task IDs and titles
+   - Completion status (✅ Done / 🔄 In Progress)
+   - Approval status (✅ Approved / ⏳ Pending)
+
+WORKFLOW POSITION:
+This tool is called:
+- Immediately after planning to get the first task
+- After approve_task_completion to get the next task
+- NEVER directly after mark_task_done
+
+OUTPUT INTERPRETATION:
+- If status is "next_task": Execute the provided task
+- If status is "all_tasks_done": Request final approval from user
+- For any other status: Handle the specific condition appropriately`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" }
+    },
+    required: ["requestId"]
+  }
+};
+
+const MARK_TASK_DONE_TOOL: Tool = {
+  name: "mark_task_done",
+  description: `Use mark_task_done after successfully completing a task's requirements.
+
+MANDATORY PARAMETERS:
+- requestId (string): The request containing the task
+- taskId (string): The specific task being marked complete
+
+OPTIONAL PARAMETERS:
+- completedDetails (string): Detailed documentation of how the task was completed, including:
+  - Specific actions taken
+  - Results achieved
+  - Any relevant outputs or artifacts
+  - Deviations from original plan (if any)
+
+EXECUTION PROTOCOL:
+
+1. COMPLETION VERIFICATION
+   Before calling this tool, ensure:
+   - Task requirements are fully satisfied
+   - All success criteria are met
+   - Any outputs are properly documented
+   - No partial completions - task must be 100% done
+
+2. STATUS UPDATE
+   The tool will:
+   - Set task status to "done"
+   - Record completion details
+   - Update progress table
+   - Display current workflow state
+
+3. APPROVAL CHECKPOINT ACTIVATION
+   CRITICAL: After marking done, the workflow enters a mandatory approval state
+   
+   YOU MUST:
+   - STOP all task progression immediately
+   - NOT call get_next_task
+   - WAIT for user approval via approve_task_completion
+   - Inform the user that approval is required
+
+4. COMPLETION DOCUMENTATION
+   Use completedDetails to provide:
+   - Summary of actions performed
+   - Key results or outputs
+   - Any issues encountered and resolutions
+   - Verification that success criteria were met
+
+ERROR CONDITIONS:
+- "already_done": Task was previously marked complete
+- "error": Invalid requestId or taskId
+
+POST-EXECUTION REQUIREMENT:
+After successful execution, you MUST:
+1. Inform the user the task is complete
+2. Explicitly request approval before proceeding
+3. NOT attempt to retrieve the next task
+4. Display the updated progress table showing the task as done but pending approval
+
+WORKFLOW POSITION:
+This tool is called:
+- After successfully executing a task retrieved via get_next_task
+- Before requesting user approval
+- Never for the same task twice`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" },
+      taskId: { type: "string" },
+      completedDetails: { type: "string" }
+    },
+    required: ["requestId", "taskId"]
+  }
+};
+
+const APPROVE_TASK_COMPLETION_TOOL: Tool = {
+  name: "approve_task_completion",
+  description: `Use approve_task_completion to approve a completed task only when all self-approval requirements are met: 1. All task objectives are fully achieved as per the task description, verified by cross-referencing actions taken. 2. Execution completed without any errors, exceptions, or failures, confirmed via logs or tests. 3. Results precisely match the predefined success criteria outlined in the task. 4. Comprehensive documentation is provided, including detailed steps, outcomes, rationale, and any deviations.
+
+MANDATORY PARAMETERS:
+- requestId (string): The request containing the completed task
+- taskId (string): The specific task being approved
+
+APPROVAL PROTOCOL:
+
+1. PREREQUISITE VALIDATION
+   The tool verifies:
+   - Task exists in the specified request
+   - Task is marked as done
+   - Task has not been previously approved
+   - Approval is pending
+
+2. APPROVAL PROCESSING
+   Upon invocation:
+   - Task approval status changes to "approved"
+   - Progress table updates to reflect approval
+   - Workflow is unblocked for progression
+   - Assistant can now call get_next_task
+
+3. DECISION POINTS
+   If requirements are not met:
+   - Workflow remains blocked
+   - May require task revision
+   - May require task re-execution
+   - May modify task requirements via update_task
+   - May abandon task via delete_task
+
+4. PROGRESS VISUALIZATION
+   A comprehensive progress table displays:
+   - All tasks with completion status
+   - Current approval states
+   - Clear indication of which task awaits approval
+
+WORKFLOW IMPLICATIONS:
+- Approval unlocks get_next_task for the assistant
+- Without approval, no forward progress is possible
+- Multiple approval cycles may occur if revisions are needed
+- Approval is irreversible once granted
+
+ASSISTANT BEHAVIOR:
+When this tool is called:
+1. Acknowledge the approval
+2. Update internal workflow state
+3. Proceed to get_next_task for next pending task
+4. If no tasks remain, prepare for request completion approval
+
+CONTROL:
+This tool represents a critical control point where the assistant:
+- Validates quality of work
+- Ensures requirements are met
+- Maintains oversight of the workflow
+- Can halt or redirect execution as needed`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" },
+      taskId: { type: "string" }
+    },
+    required: ["requestId", "taskId"]
+  }
+};
+
+const APPROVE_REQUEST_COMPLETION_TOOL: Tool = {
+  name: "approve_request_completion",
+  description: `Use approve_request_completion to finalize a request only when all tasks are completed, approved, and self-approval requirements are met across the request: 1. All task objectives are fully achieved as per the task description, verified by cross-referencing actions taken. 2. Execution completed without any errors, exceptions, or failures, confirmed via logs or tests. 3. Results precisely match the predefined success criteria outlined in the task. 4. Comprehensive documentation is provided, including detailed steps, outcomes, rationale, and any deviations.
+
+MANDATORY PARAMETERS:
+- requestId (string): The request to be finalized
+
+FINALIZATION PROTOCOL:
+
+1. PREREQUISITE VERIFICATION
+   The tool validates:
+   - All tasks in the request are marked done
+   - All completed tasks have been individually approved
+   - Request is not already finalized
+   - No pending tasks remain
+
+2. COMPLETION PROCESSING
+   Upon invocation:
+   - Request status changes to "completed"
+   - Workflow is formally closed
+   - Request becomes read-only (no further modifications)
+   - Final progress table is displayed
+
+3. DECISION ALTERNATIVES
+   If requirements are not met:
+   - Request remains active
+   - Can add new tasks via add_tasks_to_request
+   - Can create supplementary tasks
+   - Workflow continues with new task cycle
+
+4. FINAL STATE VISUALIZATION
+   A comprehensive final progress table shows:
+   - All tasks with ✅ Done status
+   - All tasks with ✅ Approved status
+   - Request summary and completion metrics
+   - Confirmation of successful closure
+
+WORKFLOW TERMINATION:
+- This represents the absolute end of a request lifecycle
+- No further modifications possible after approval
+- Request enters permanent archive state
+- New requests must be created for additional work
+
+ASSISTANT BEHAVIOR:
+When this tool is called:
+1. Acknowledge request completion
+2. Provide final summary of accomplished work
+3. Confirm no further actions possible on this request
+4. Offer to create new request if additional needs arise
+
+COMPLETION CRITERIA:
+Approve when:
+- Original request objectives are fully met
+- All deliverables are satisfactory
+- No additional tasks are needed
+- Quality standards are achieved
+
+POST-COMPLETION:
+After approval, the request serves as:
+- Historical record of work performed
+- Reference for similar future requests
+- Audit trail of approvals and completions`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" }
+    },
+    required: ["requestId"]
+  }
+};
+
+const OPEN_TASK_DETAILS_TOOL: Tool = {
+  name: "open_task_details",
+  description: `Use open_task_details to inspect detailed information about any task.
+
+MANDATORY PARAMETERS:
+- taskId (string): The unique identifier of the task to inspect
+
+RETRIEVAL PROTOCOL:
+
+1. TASK LOOKUP
+   The tool searches across all requests to find the specified task
+   - No requestId needed - taskId is globally unique
+   - Returns full task context including parent request
+   - Works for tasks in any state (pending, done, approved)
+
+2. INFORMATION PROVIDED
+   Returns comprehensive task data:
+   
+   Task Details:
+   - id: Unique task identifier
+   - title: Task name
+   - description: Full task specification
+   - done: Completion status (true/false)
+   - approved: Approval status (true/false)
+   - completedDetails: Documentation of how task was completed
+   
+   Request Context:
+   - requestId: Parent request identifier
+   - originalRequest: Initial user request
+   - splitDetails: Task decomposition rationale
+   - completed: Request finalization status
+
+3. USE CASES
+   Invoke this tool when:
+   - User asks about specific task status
+   - Clarification needed on task requirements
+   - Reviewing completion details
+   - Debugging workflow issues
+   - Verifying task dependencies
+
+4. ERROR HANDLING
+   - "task_not_found": Invalid taskId provided
+   - Returns error message for non-existent tasks
+
+OPERATIONAL NOTES:
+- This is a read-only operation
+- Does not affect workflow state
+- Can be called at any time
+- Useful for providing user with task clarity
+- Helps maintain context in long workflows
+
+TYPICAL WORKFLOW INTEGRATION:
+1. User queries about a specific task
+2. Assistant calls open_task_details with taskId
+3. Assistant presents the detailed information
+4. User makes informed decisions about task handling
+
+OUTPUT UTILIZATION:
+Use the returned data to:
+- Answer user questions about task state
+- Verify completion criteria were met
+- Review approval history
+- Understand task context within larger request`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      taskId: { type: "string" }
+    },
+    required: ["taskId"]
+  }
+};
+
+const LIST_REQUESTS_TOOL: Tool = {
+  name: "list_requests",
+  description: `Use list_requests to display all requests in the system.
+
+PARAMETERS: None required (empty object {})
+
+RETRIEVAL PROTOCOL:
+
+1. SYSTEM-WIDE SCAN
+   The tool aggregates data from all requests:
+   - Active requests (in progress)
+   - Completed requests (finalized)
+   - Requests with mixed task states
+   - All historical requests in the system
+
+2. INFORMATION PROVIDED
+   
+   Summary Table Format:
+   | Request ID | Original Request | Total Tasks | Completed | Approved |
+   
+   Each row contains:
+   - requestId: Unique request identifier
+   - originalRequest: First 30 characters of request (truncated if longer)
+   - totalTasks: Number of tasks in request
+   - completedTasks: Count of done tasks
+   - approvedTasks: Count of approved tasks
+
+3. USE CASES
+   Invoke this tool when:
+   - User needs workflow overview
+   - Selecting which request to work on
+   - Checking overall progress
+   - Identifying stalled requests
+   - Planning workload distribution
+
+4. DATA INTERPRETATION
+   Request States:
+   - Active: completedTasks < totalTasks
+   - Awaiting Approval: completedTasks = totalTasks but approvedTasks < totalTasks
+   - Finalizable: All tasks done and approved
+   - Completed: Request marked as finished
+
+OPERATIONAL WORKFLOW:
+1. User requests system overview
+2. Assistant calls list_requests
+3. Assistant presents formatted table
+4. User identifies request of interest
+5. Assistant can then use get_next_task with chosen requestId
+
+DECISION SUPPORT:
+The overview helps users:
+- Prioritize which requests to focus on
+- Identify bottlenecks (unapproved tasks)
+- Track overall system utilization
+- Plan new request creation
+- Monitor completion rates
+
+FOLLOW-UP ACTIONS:
+Based on the list, typical next steps:
+- Select a request to continue work
+- Identify requests needing approval
+- Create new requests for unaddressed needs
+- Archive completed requests mentally`,
+  inputSchema: {
+    type: "object",
+    properties: {}
+  }
+};
+
+const ADD_TASKS_TO_REQUEST_TOOL: Tool = {
+  name: "add_tasks_to_request",
+  description: `Use add_tasks_to_request to extend an existing request with new tasks.
+
+MANDATORY PARAMETERS:
+- requestId (string): The target request to extend
+- tasks (array): New task objects, each containing:
+  - title (string): Concise task identifier
+  - description (string): Detailed task specification
+
+EXTENSION PROTOCOL:
+
+1. REQUEST VALIDATION
+   Before adding tasks, the tool verifies:
+   - Request exists and is valid
+   - Request is not already completed/finalized
+   - Request can accept new tasks
+   
+   CONSTRAINT: Cannot add tasks to completed requests
+
+2. TASK INTEGRATION
+   New tasks will:
+   - Receive unique taskIds
+   - Be appended to existing task list
+   - Appear in workflow queue after current tasks
+   - Follow standard approval cycle
+
+3. USE CASES
+   Add tasks when:
+   - User identifies additional requirements
+   - Original scope was incomplete
+   - Emergent needs arise during execution
+   - Iterative refinement is needed
+   - User rejects completion and wants more work
+
+4. WORKFLOW CONTINUITY
+   After adding tasks:
+   - Progress table updates to show all tasks
+   - New tasks enter pending state
+   - Existing workflow continues normally
+   - get_next_task will eventually reach new tasks
+
+STRATEGIC CONSIDERATIONS:
+- Maintains workflow momentum (no restart needed)
+- Preserves completed work and approvals
+- Enables agile scope adjustment
+- Supports iterative development approach
+
+TYPICAL SCENARIO:
+1. All original tasks completed
+2. User reviews and wants additional work
+3. Instead of approving completion, user defines new tasks
+4. Assistant calls add_tasks_to_request
+5. Workflow continues with expanded scope
+
+OUTPUT STRUCTURE:
+Returns confirmation with:
+- Number of tasks added
+- Updated progress table
+- New task details with assigned IDs
+- Current workflow state
+
+POST-EXECUTION:
+After adding tasks:
+- Continue current workflow normally
+- New tasks will be retrieved via get_next_task
+- Standard approval cycle applies to new tasks
+- Request remains active until all tasks complete`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" },
+      tasks: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            description: { type: "string" }
+          },
+          required: ["title", "description"]
+        }
+      }
+    },
+    required: ["requestId", "tasks"]
+  }
+};
+
+const UPDATE_TASK_TOOL: Tool = {
+  name: "update_task",
+  description: `Use update_task to modify existing task details.
+
+MANDATORY PARAMETERS:
+- requestId (string): The request containing the task
+- taskId (string): The task to update
+
+OPTIONAL PARAMETERS (at least one required):
+- title (string): New task title
+- description (string): New task description
+
+UPDATE PROTOCOL:
+
+1. MODIFICATION CONSTRAINTS
+   Tasks can only be updated if:
+   - Task exists in specified request
+   - Task is NOT marked as done
+   - Task is NOT approved
+   - Request is NOT completed
+   
+   CRITICAL: Completed tasks are immutable for audit integrity
+
+2. PERMISSIBLE UPDATES
+   You can modify:
+   - Task title for clarity
+   - Task description for better specifications
+   - Both title and description simultaneously
+   
+   You CANNOT modify:
+   - Task ID
+   - Completion status
+   - Approval status
+   - Historical completion details
+
+3. USE CASES
+   Update tasks when:
+   - User clarifies requirements
+   - Ambiguity discovered during execution
+   - Scope refinement needed
+   - Better description would aid execution
+   - User feedback requires specification change
+
+4. WORKFLOW IMPACT
+   Updates take effect immediately:
+   - Progress table reflects changes
+   - Next retrieval shows updated details
+   - No workflow disruption occurs
+   - Task position in queue unchanged
+
+ERROR CONDITIONS:
+- Cannot update completed tasks
+- Cannot update non-existent tasks
+- Cannot update tasks in completed requests
+
+TYPICAL WORKFLOW:
+1. User identifies need for task clarification
+2. Assistant calls update_task with new details
+3. Updated progress table displayed
+4. Workflow continues with refined task
+5. Task executed according to new specification
+
+BEST PRACTICES:
+- Update before starting task execution
+- Preserve original intent while clarifying
+- Document why update was needed
+- Ensure updates align with overall request goals
+
+POST-UPDATE:
+- Task remains in current workflow position
+- Standard execution and approval cycle continues
+- Updated details used for execution
+- Historical record maintains update transaction`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" },
+      taskId: { type: "string" },
+      title: { type: "string" },
+      description: { type: "string" }
+    },
+    required: ["requestId", "taskId"]
+  }
+};
+
+const DELETE_TASK_TOOL: Tool = {
+  name: "delete_task",
+  description: `Use delete_task to permanently remove a task from a request.
+
+MANDATORY PARAMETERS:
+- requestId (string): The request containing the task
+- taskId (string): The task to delete
+
+DELETION PROTOCOL:
+
+1. DELETION CONSTRAINTS
+   Tasks can only be deleted if:
+   - Task exists in specified request
+   - Task is NOT marked as done
+   - Task is NOT approved
+   - Request is NOT completed
+   
+   CRITICAL: Completed tasks cannot be deleted to maintain audit trail
+
+2. DELETION IMPACT
+   Upon deletion:
+   - Task is permanently removed from request
+   - Task ID becomes invalid
+   - Progress table updates to reflect removal
+   - Workflow continues with remaining tasks
+   - No recovery possible (irreversible)
+
+3. USE CASES
+   Delete tasks when:
+   - Task was created in error
+   - Requirement is no longer applicable
+   - Duplicate task was accidentally created
+   - Scope change eliminates need
+   - User decides task is unnecessary
+
+4. WORKFLOW CONTINUITY
+   After deletion:
+   - Remaining tasks maintain their order
+   - No gaps in task execution
+   - get_next_task skips to next valid task
+   - Overall request can still complete normally
+
+ERROR CONDITIONS:
+- Cannot delete completed tasks
+- Cannot delete approved tasks
+- Cannot delete from completed requests
+- Cannot delete non-existent tasks
+
+SAFETY CONSIDERATIONS:
+- Deletion is permanent and irreversible
+- No undo mechanism exists
+- Completed work is protected from deletion
+- Maintains data integrity for audit purposes
+
+TYPICAL WORKFLOW:
+1. User identifies unnecessary task
+2. User confirms task hasn't been started
+3. Assistant calls delete_task
+4. Confirmation shows updated task list
+5. Workflow continues with reduced scope
+
+ALTERNATIVE TO DELETION:
+If task is already completed:
+- Cannot delete
+- Can only proceed through approval cycle
+- User can choose not to approve
+- Completed task remains in historical record
+
+POST-DELETION STATE:
+- Progress table shows remaining tasks only
+- Deleted task ID no longer valid
+- Request can complete with fewer tasks
+- No impact on other task executions`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      requestId: { type: "string" },
+      taskId: { type: "string" }
+    },
+    required: ["requestId", "taskId"]
+  }
+};
+
+class TasksServer {
+  private requestCounter = 0;
+  private taskCounter = 0;
+  private data: TasksFile = { requests: [] };
+
+  constructor() {
+    this.loadTasks();
+  }
+
+  private async loadTasks() {
+    try {
+      const data = await fs.readFile(TASK_FILE_PATH, "utf-8");
+      this.data = JSON.parse(data);
+      const allTaskIds: number[] = [];
+      const allRequestIds: number[] = [];
+
+      for (const req of this.data.requests) {
+        const reqNum = Number.parseInt(req.requestId.replace("req-", ""), 10);
+        if (!Number.isNaN(reqNum)) {
+          allRequestIds.push(reqNum);
+        }
+        for (const t of req.tasks) {
+          const tNum = Number.parseInt(t.id.replace("task-", ""), 10);
+          if (!Number.isNaN(tNum)) {
+            allTaskIds.push(tNum);
+          }
+        }
+      }
+
+      this.requestCounter =
+        allRequestIds.length > 0 ? Math.max(...allRequestIds) : 0;
+      this.taskCounter = allTaskIds.length > 0 ? Math.max(...allTaskIds) : 0;
+    } catch {
+      this.data = { requests: [] };
+    }
+  }
+
+  private async saveTasks() {
+    try {
+      await fs.writeFile(
+        TASK_FILE_PATH,
+        JSON.stringify(this.data, null, 2),
+        "utf-8"
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("EROFS")) {
+        console.error("EROFS: read-only file system. Cannot save tasks.");
+        throw error;
+      }
+      throw error;
+    }
+  }
+
+  private formatTaskProgressTable(requestId: string): string {
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return "Request not found";
+
+    let table = "\nProgress:\n";
+    table += "| Task ID | Title | Description | Status | Approval |\n";
+    table += "|----------|----------|------|------|----------|\n";
+
+    for (const task of req.tasks) {
+      const status = task.done ? "✅ Done" : "🔄 In Progress";
+      const approved = task.approved ? "✅ Approved" : "⏳ Pending";
+      table += `| ${task.id} | ${task.title} | ${task.description} | ${status} | ${approved} |\n`;
+    }
+
+    return table;
+  }
+
+  private formatRequestsList(): string {
+    let output = "\nRequest List:\n";
+    output +=
+      "| Request ID | Original Request | Total Tasks | Completed | Approved |\n";
+    output +=
+      "|------------|------------------|-------------|-----------|----------|\n";
+
+    for (const req of this.data.requests) {
+      const totalTasks = req.tasks.length;
+      const completedTasks = req.tasks.filter((t) => t.done).length;
+      const approvedTasks = req.tasks.filter((t) => t.approved).length;
+      output += `| ${req.requestId} | ${req.originalRequest.substring(0, 30)}${req.originalRequest.length > 30 ? "..." : ""} | ${totalTasks} | ${completedTasks} | ${approvedTasks} |\n`;
+    }
+
+    return output;
+  }
+
+  public async requestPlanning(
+    originalRequest: string,
+    tasks: { title: string; description: string }[],
+    splitDetails?: string
+  ) {
+    await this.loadTasks();
+    this.requestCounter += 1;
+    const requestId = `req-${this.requestCounter}`;
+
+    const newTasks: Task[] = [];
+    for (const taskDef of tasks) {
+      this.taskCounter += 1;
+      newTasks.push({
+        id: `task-${this.taskCounter}`,
+        title: taskDef.title,
+        description: taskDef.description,
+        done: false,
+        approved: false,
+        completedDetails: ""
+      });
+    }
+
+    this.data.requests.push({
+      requestId,
+      originalRequest,
+      splitDetails: splitDetails || originalRequest,
+      tasks: newTasks,
+      completed: false
+    });
+
+    await this.saveTasks();
+
+    const progressTable = this.formatTaskProgressTable(requestId);
+
+    return {
+      status: "planned",
+      requestId,
+      totalTasks: newTasks.length,
+      tasks: newTasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.description
+      })),
+      message: `Tasks have been successfully added. Please use 'get_next_task' to retrieve the first task.\n${progressTable}`
+    };
+  }
+
+  public async getNextTask(requestId: string) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) {
+      return { status: "error", message: "Request not found" };
+    }
+    if (req.completed) {
+      return {
+        status: "already_completed",
+        message: "Request already completed."
+      };
+    }
+    const nextTask = req.tasks.find((t) => !t.done);
+    if (!nextTask) {
+      // all tasks done?
+      const allDone = req.tasks.every((t) => t.done);
+      if (allDone && !req.completed) {
+        const progressTable = this.formatTaskProgressTable(requestId);
+        return {
+          status: "all_tasks_done",
+          message: `All tasks have been completed. Awaiting request completion approval.\n${progressTable}`
+        };
+      }
+      return { status: "no_next_task", message: "No undone tasks found." };
+    }
+
+    const progressTable = this.formatTaskProgressTable(requestId);
+    return {
+      status: "next_task",
+      task: {
+        id: nextTask.id,
+        title: nextTask.title,
+        description: nextTask.description
+      },
+      message: `Next task is ready. Task approval will be required after completion.\n${progressTable}`
+    };
+  }
+
+  public async markTaskDone(
+    requestId: string,
+    taskId: string,
+    completedDetails?: string
+  ) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+    const task = req.tasks.find((t) => t.id === taskId);
+    if (!task) return { status: "error", message: "Task not found" };
+    if (task.done)
+      return {
+        status: "already_done",
+        message: "Task is already marked done."
+      };
+
+    task.done = true;
+    task.completedDetails = completedDetails || "";
+    await this.saveTasks();
+    return {
+      status: "task_marked_done",
+      requestId: req.requestId,
+      task: {
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        completedDetails: task.completedDetails,
+        approved: task.approved
+      }
+    };
+  }
+
+  public async approveTaskCompletion(requestId: string, taskId: string) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+    const task = req.tasks.find((t) => t.id === taskId);
+    if (!task) return { status: "error", message: "Task not found" };
+    if (!task.done) return { status: "error", message: "Task not done yet." };
+    if (task.approved)
+      return { status: "already_approved", message: "Task already approved." };
+
+    task.approved = true;
+    await this.saveTasks();
+    return {
+      status: "task_approved",
+      requestId: req.requestId,
+      task: {
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        completedDetails: task.completedDetails,
+        approved: task.approved
+      }
+    };
+  }
+
+  public async approveRequestCompletion(requestId: string) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+
+    // Check if all tasks are done and approved
+    const allDone = req.tasks.every((t) => t.done);
+    if (!allDone) {
+      return { status: "error", message: "Not all tasks are done." };
+    }
+    const allApproved = req.tasks.every((t) => t.done && t.approved);
+    if (!allApproved) {
+      return { status: "error", message: "Not all done tasks are approved." };
+    }
+
+    req.completed = true;
+    await this.saveTasks();
+    return {
+      status: "request_approved_complete",
+      requestId: req.requestId,
+      message: "Request is fully completed and approved."
+    };
+  }
+
+  public async openTaskDetails(taskId: string) {
+    await this.loadTasks();
+    for (const req of this.data.requests) {
+      const target = req.tasks.find((t) => t.id === taskId);
+      if (target) {
+        return {
+          status: "task_details",
+          requestId: req.requestId,
+          originalRequest: req.originalRequest,
+          splitDetails: req.splitDetails,
+          completed: req.completed,
+          task: {
+            id: target.id,
+            title: target.title,
+            description: target.description,
+            done: target.done,
+            approved: target.approved,
+            completedDetails: target.completedDetails
+          }
+        };
+      }
+    }
+    return { status: "task_not_found", message: "No such task found" };
+  }
+
+  public async listRequests() {
+    await this.loadTasks();
+    const requestsList = this.formatRequestsList();
+    return {
+      status: "requests_listed",
+      message: `Current requests in the system:\n${requestsList}`,
+      requests: this.data.requests.map((req) => ({
+        requestId: req.requestId,
+        originalRequest: req.originalRequest,
+        totalTasks: req.tasks.length,
+        completedTasks: req.tasks.filter((t) => t.done).length,
+        approvedTasks: req.tasks.filter((t) => t.approved).length
+      }))
+    };
+  }
+
+  public async addTasksToRequest(
+    requestId: string,
+    tasks: { title: string; description: string }[]
+  ) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+    if (req.completed)
+      return {
+        status: "error",
+        message: "Cannot add tasks to completed request"
+      };
+
+    const newTasks: Task[] = [];
+    for (const taskDef of tasks) {
+      this.taskCounter += 1;
+      newTasks.push({
+        id: `task-${this.taskCounter}`,
+        title: taskDef.title,
+        description: taskDef.description,
+        done: false,
+        approved: false,
+        completedDetails: ""
+      });
+    }
+
+    req.tasks.push(...newTasks);
+    await this.saveTasks();
+
+    const progressTable = this.formatTaskProgressTable(requestId);
+    return {
+      status: "tasks_added",
+      message: `Added ${newTasks.length} new tasks to request.\n${progressTable}`,
+      newTasks: newTasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.description
+      }))
+    };
+  }
+
+  public async updateTask(
+    requestId: string,
+    taskId: string,
+    updates: { title?: string; description?: string }
+  ) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+
+    const task = req.tasks.find((t) => t.id === taskId);
+    if (!task) return { status: "error", message: "Task not found" };
+    if (task.done)
+      return { status: "error", message: "Cannot update completed task" };
+
+    if (updates.title) task.title = updates.title;
+    if (updates.description) task.description = updates.description;
+
+    await this.saveTasks();
+
+    const progressTable = this.formatTaskProgressTable(requestId);
+    return {
+      status: "task_updated",
+      message: `Task ${taskId} has been updated.\n${progressTable}`,
+      task: {
+        id: task.id,
+        title: task.title,
+        description: task.description
+      }
+    };
+  }
+
+  public async deleteTask(requestId: string, taskId: string) {
+    await this.loadTasks();
+    const req = this.data.requests.find((r) => r.requestId === requestId);
+    if (!req) return { status: "error", message: "Request not found" };
+
+    const taskIndex = req.tasks.findIndex((t) => t.id === taskId);
+    if (taskIndex === -1) return { status: "error", message: "Task not found" };
+    // After checking taskIndex !== -1, we know the task exists
+    if (req.tasks[taskIndex]!.done)
+      return { status: "error", message: "Cannot delete completed task" };
+
+    req.tasks.splice(taskIndex, 1);
+    await this.saveTasks();
+
+    const progressTable = this.formatTaskProgressTable(requestId);
+    return {
+      status: "task_deleted",
+      message: `Task ${taskId} has been deleted.\n${progressTable}`
+    };
+  }
+}
+
+const server = new Server(
+  {
+    name: "tasks-server",
+    version: "0.0.3"
+  },
+  {
+    capabilities: {
+      tools: {}
+    }
+  }
+);
+
+const tasksServer = new TasksServer();
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    PLANNING_TOOL,
+    GET_NEXT_TASK_TOOL,
+    MARK_TASK_DONE_TOOL,
+    APPROVE_TASK_COMPLETION_TOOL,
+    APPROVE_REQUEST_COMPLETION_TOOL,
+    OPEN_TASK_DETAILS_TOOL,
+    LIST_REQUESTS_TOOL,
+    ADD_TASKS_TO_REQUEST_TOOL,
+    UPDATE_TASK_TOOL,
+    DELETE_TASK_TOOL
+  ]
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    const { name, arguments: args } = request.params;
+
+    switch (name) {
+      case "planning": {
+        const parsed = RequestPlanningSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { originalRequest, tasks, splitDetails } = parsed.data;
+        const result = await tasksServer.requestPlanning(
+          originalRequest,
+          tasks,
+          splitDetails
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "get_next_task": {
+        const parsed = GetNextTaskSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const result = await tasksServer.getNextTask(parsed.data.requestId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "mark_task_done": {
+        const parsed = MarkTaskDoneSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId, taskId, completedDetails } = parsed.data;
+        const result = await tasksServer.markTaskDone(
+          requestId,
+          taskId,
+          completedDetails
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "approve_task_completion": {
+        const parsed = ApproveTaskCompletionSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId, taskId } = parsed.data;
+        const result = await tasksServer.approveTaskCompletion(
+          requestId,
+          taskId
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "approve_request_completion": {
+        const parsed = ApproveRequestCompletionSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId } = parsed.data;
+        const result = await tasksServer.approveRequestCompletion(requestId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "open_task_details": {
+        const parsed = OpenTaskDetailsSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { taskId } = parsed.data;
+        const result = await tasksServer.openTaskDetails(taskId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "list_requests": {
+        const parsed = ListRequestsSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const result = await tasksServer.listRequests();
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "add_tasks_to_request": {
+        const parsed = AddTasksToRequestSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId, tasks } = parsed.data;
+        const result = await tasksServer.addTasksToRequest(requestId, tasks);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "update_task": {
+        const parsed = UpdateTaskSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId, taskId, title, description } = parsed.data;
+        const result = await tasksServer.updateTask(requestId, taskId, {
+          title,
+          description
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      case "delete_task": {
+        const parsed = DeleteTaskSchema.safeParse(args);
+        if (!parsed.success) {
+          throw new Error(`Invalid arguments: ${parsed.error!.message}`);
+        }
+        const { requestId, taskId } = parsed.data;
+        const result = await tasksServer.deleteTask(requestId, taskId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true
+    };
+  }
+});
+
+async function runServer() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`Tasks MCP Server running. Saving tasks at: ${TASK_FILE_PATH}`);
+}
+
+runServer().catch((error) => {
+  console.error("Fatal error running server:", error);
+  process.exit(1);
+});

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -878,6 +878,10 @@ class TasksServer {
 
   private async saveTasks() {
     try {
+      // Ensure directory exists
+      const dir = path.dirname(TASK_FILE_PATH);
+      await fs.mkdir(dir, { recursive: true });
+
       await fs.writeFile(
         TASK_FILE_PATH,
         JSON.stringify(this.data, null, 2),
@@ -1230,7 +1234,7 @@ class TasksServer {
 const server = new Server(
   {
     name: "tasks-server",
-    version: "0.0.3"
+    version: "0.0.6"
   },
   {
     capabilities: {

--- a/src/tasks/package.json
+++ b/src/tasks/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@wemake-ai/mcpserver-tasks",
+  "version": "0.0.5",
+  "description": "Model Context Protocol server for Tasks",
+  "license": "MIT",
+  "author": "WeMake (https://wemake.cx)",
+  "homepage": "https://wemake.cx",
+  "bugs": "https://github.com/WeMake-ai/mcp/issues",
+  "type": "module",
+  "bin": {
+    "mcpserver-tasks": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bun build --target=bun --outfile=dist/index.js index.ts",
+    "prepare": "bun run build",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "0.5.0",
+    "chalk": "^5.3.0",
+    "glob": "^10.3.10",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "@types/json-schema": "^7.0.15",
+    "@types/node": "^20.11.0",
+    "shx": "^0.3.4",
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/tasks/package.json
+++ b/src/tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcpserver-tasks",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Model Context Protocol server for Tasks",
   "license": "MIT",
   "author": "WeMake (https://wemake.cx)",

--- a/src/tasks/package.json
+++ b/src/tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcpserver-tasks",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Model Context Protocol server for Tasks",
   "license": "MIT",
   "author": "WeMake (https://wemake.cx)",
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "bun build --target=bun --outfile=dist/index.js index.ts",
+    "build": "bun build --insert-shebang --target=bun --outfile=dist/index.js index.ts",
     "prepare": "bun run build",
     "watch": "tsc --watch"
   },

--- a/src/tasks/tsconfig.json
+++ b/src/tasks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
Add new MCP server for task management including package.json, tsconfig.json, and README.md.
Update root package.json to include tasks build and publish scripts.
Adjust deep-thinking package version and remove redundant publish script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standalone Tasks MCP Server for managing and executing task workflows, including planning, execution, approval, and detailed task operations.
  * Added a new package for the tasks server with dedicated build and publish scripts.

* **Documentation**
  * Added comprehensive README for the Tasks MCP Server, detailing configuration, usage, and operational phases.
  * Updated main README to include the new Tasks server under the Servers section.

* **Chores**
  * Updated and reorganized scripts in project configuration files for building, publishing, linting, and type checking.
  * Added TypeScript configuration for the tasks server package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->