### PR TITLE
feat(knowledge-graph): migrate from JSONL to JSON format for memory storage

### DIFF
--- a/.wemake/tasks.json
+++ b/.wemake/tasks.json
@@ -1,0 +1,52 @@
+{
+  "requests": [
+    {
+      "requestId": "req-1",
+      "originalRequest": "Update `/Users/admin/Repositories/WeMake/mcp/src/knowledge-graph-memory/` to utilize a scalable `knowledge.json` (JSON) instead of currently `knowledge.jsonl` (JSON Lines). `MCP`",
+      "splitDetails": "Decomposing into analysis, design, implementation, documentation, and testing phases for thorough update.",
+      "tasks": [
+        {
+          "id": "task-1",
+          "title": "Analyze current implementation",
+          "description": "Examine the existing code in index.ts and related files to understand how knowledge.jsonl is used, including reading, writing, and any scalability issues.",
+          "done": true,
+          "approved": true,
+          "completedDetails": "Analyzed index.ts: knowledge.jsonl stores entities and relations as separate JSON objects per line. Loading reads entire file, parses lines into graph structure. Saving writes all lines to temp file then renames. Scalability concerns: Full memory load for operations may not scale with very large graphs; no indexing for efficient queries; appending is efficient but searches require full load."
+        },
+        {
+          "id": "task-2",
+          "title": "Design JSON structure",
+          "description": "Plan a scalable JSON structure to replace JSONL, ensuring it can handle large amounts of data efficiently.",
+          "done": true,
+          "approved": true,
+          "completedDetails": "Planned JSON structure: Single knowledge.json file containing { \"entities\": [ { \"name\": string, \"entityType\": string, \"observations\": string[] } ], \"relations\": [ { \"from\": string, \"to\": string, \"relationType\": string } ] }. For scalability, maintain in-memory maps for quick access (e.g., entity name to object), append-only where possible, but full rewrite on changes. Address large data by suggesting size limits or future migration to database if needed."
+        },
+        {
+          "id": "task-3",
+          "title": "Modify code to use JSON",
+          "description": "Update the code to read from and write to knowledge.json instead of knowledge.jsonl, implementing necessary changes for scalability.",
+          "done": true,
+          "approved": true,
+          "completedDetails": "Updated MEMORY_FILE_PATH to 'knowledge.json'. Modified loadGraph to parse the JSON file directly into entities and relations arrays with structure validation. Updated saveGraph to construct a clean JSON object (removing 'type' fields) and write it with indentation. This completes the transition to a scalable JSON format, maintaining in-memory operations while noting persistence requires full rewrites."
+        },
+        {
+          "id": "task-4",
+          "title": "Update configuration and documentation",
+          "description": "Adjust package.json, README.md, and any other files to reflect the change, and document the new format.",
+          "done": true,
+          "approved": true,
+          "completedDetails": "Updated README.md: Changed references from knowledge.jsonl to knowledge.json in the custom path example and default path description. Added a new 'Data Format' section documenting the JSON structure with entities and relations arrays. package.json requires no updates as it contains no references to the memory file."
+        },
+        {
+          "id": "task-5",
+          "title": "Test the updated implementation",
+          "description": "Create and run tests to verify the new JSON-based system works correctly and scales appropriately.",
+          "done": true,
+          "approved": true,
+          "completedDetails": "Created index.test.ts with unit tests for creating/reading entities, creating relations, adding observations, deleting entities, and scalability with 1000 entities. Fixed bugs in index.ts including exporting the class, adding a constructor for custom file paths, and correcting the rename in saveGraph to use this.memoryFilePath. Ran bun test, and all 5 tests passed successfully, verifying the new JSON-based system functions correctly and handles larger datasets in memory."
+        }
+      ],
+      "completed": true
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "src/knowledge-graph-memory": {
       "name": "@wemake-ai/mcpserver-knowledge-graph-memory",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "mcpserver-knowledge-graph-memory": "dist/index.js",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcp",
-  "version": "25.3.0",
+  "version": "25.3.1",
   "author": "WeMake (https://wemake.cx)",
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/knowledge-graph-memory/README.md
+++ b/src/knowledge-graph-memory/README.md
@@ -193,7 +193,7 @@ You can specify a custom path for the memory file:
         "-y",
         "@wemake-ai/mcpserver-knowledge-graph-memory",
         "--memory-path",
-        "/home/alice/project/.wemake/knowledge.jsonl"
+        "/home/alice/project/.wemake/knowledge.json"
       ],
       "autoapprove": [
         "create_entities",
@@ -211,8 +211,34 @@ You can specify a custom path for the memory file:
 }
 ```
 
-If no path is specified, it will default to knowledge.jsonl in the server's
+If no path is specified, it will default to knowledge.json in the server's
 installation directory.
+
+## Data Format
+
+The knowledge graph is stored in a single JSON file with the following
+structure:
+
+```json
+{
+  "entities": [
+    {
+      "name": "John_Smith",
+      "entityType": "person",
+      "observations": ["Speaks fluent Spanish"]
+    }
+    // ... more entities
+  ],
+  "relations": [
+    {
+      "from": "John_Smith",
+      "to": "ExampleCorp",
+      "relationType": "works_at"
+    }
+    // ... more relations
+  ]
+}
+```
 
 ## License
 

--- a/src/knowledge-graph-memory/package.json
+++ b/src/knowledge-graph-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake-ai/mcpserver-knowledge-graph-memory",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Model Context Protocol (MCP) server enabling persistent memory for AI Agents through a local knowledge graph",
   "license": "MIT",
   "author": "WeMake (https://wemake.cx)",


### PR DESCRIPTION
Update the knowledge graph memory storage to use a structured JSON format instead of JSONL. This improves scalability and maintainability while providing better documentation of the data structure. The change includes updates to the file handling logic, documentation, and version bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved knowledge graph memory storage by switching from a line-based format to a single JSON file, enhancing scalability and data organization.

* **Documentation**
  * Updated documentation to describe the new storage format and file name, including detailed data structure examples.

* **Refactor**
  * Refactored the memory management system to use a unified JSON structure and encapsulated file path configuration.

* **Chores**
  * Incremented version numbers to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->