### PR TITLE
refactor(scripts): rename build and release scripts to build-all and publish-all

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  id-token: write # Required for OIDC
+  id-token: write
   contents: read
 
 jobs:
@@ -21,6 +21,7 @@ jobs:
           node-version: "20"
 
       - run: bun install --frozen-lockfile
-      - run: bun run build
-      - run: bun run test
-      - run: bun run release
+      - run: bun run build-all
+      - run: bun run publish-all
+        env:
+          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,7 +6,7 @@
 exact = true
 
 # Registry configuration
-registry = "https://registry.npmjs.org/"
+registry = { url = "https://registry.npmjs.org", token = "$npm_token" }
 
 # Development server configuration
 [dev]

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "packageManager": "bun@1.2.0",
   "scripts": {
     "start": "bun run --filter='./src/*' start",
-    "build": "bun run --filter='./src/*' build",
+    "build-all": "bun run --filter='./src/*' build",
     "watch": "bun run --filter='./src/*' watch",
-    "release": "bun run --filter='./src/*' release",
+    "publish-all": "bun run --filter='./src/*' publish",
     "link-all": "bun link --workspaces",
     "format": "prettier --write . && eslint . --ext .ts,.tsx --fix",
     "prettier": "prettier --check .",

--- a/src/analogical-reasoning/package.json
+++ b/src/analogical-reasoning/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/bias-detection/package.json
+++ b/src/bias-detection/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/collaborative-reasoning/package.json
+++ b/src/collaborative-reasoning/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/constraint-solver/package.json
+++ b/src/constraint-solver/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",

--- a/src/decision-framework/package.json
+++ b/src/decision-framework/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/ethical-reasoning/package.json
+++ b/src/ethical-reasoning/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/focus-group/package.json
+++ b/src/focus-group/package.json
@@ -33,11 +33,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/goal-tracker/package.json
+++ b/src/goal-tracker/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -30,11 +30,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/metacognitive-monitoring/package.json
+++ b/src/metacognitive-monitoring/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/multimodal-synthesizer/package.json
+++ b/src/multimodal-synthesizer/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/narrative-planner/package.json
+++ b/src/narrative-planner/package.json
@@ -40,11 +40,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/scientific-method/package.json
+++ b/src/scientific-method/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/sequential-thinking/package.json
+++ b/src/sequential-thinking/package.json
@@ -32,11 +32,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/structured-argumentation/package.json
+++ b/src/structured-argumentation/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"

--- a/src/transaction-manager/package.json
+++ b/src/transaction-manager/package.json
@@ -36,11 +36,12 @@
     "lib"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",

--- a/src/visual-reasoning/package.json
+++ b/src/visual-reasoning/package.json
@@ -34,11 +34,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
+    "clean": "rm -rf dist",
+    "build": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' && tsc",
     "start": "bun run ./dist/index.js",
     "prepare": "bun run build",
     "watch": "bun build ./src/index.ts --outdir='./dist' --target='bun' --sourcemap='linked' --watch",
-    "release": "bun publish"
+    "publish": "bun publish"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4"


### PR DESCRIPTION
Update package.json scripts across all packages to use more descriptive names
Extract clean step into separate script for better maintainability
Update CI workflow to use new script names and add npm token for publishing