### PR TITLE
chore: remove .npmrc and update bunfig.toml registry config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry="https://registry.npmjs.org/"
-@wemake.cx:registry="https://registry.npmjs.org/"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,7 +6,12 @@
 exact = true
 
 # Registry configuration
-registry = { url = "https://registry.npmjs.org", token = "$npm_token" }
+registry = "https://registry.npmjs.org"
+
+[install.scopes]
+
+# Registry with token
+wemake.cx = { token = "$npm_token", url = "https://registry.npmjs.org" }
 
 # Development server configuration
 [dev]


### PR DESCRIPTION
Update registry configuration to use bunfig.toml exclusively and remove redundant .npmrc file. Move token configuration to the appropriate scope in bunfig.toml.