### PR TITLE
ci: update publish workflow to use actions/checkout and move NPM_TOKEN env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: "1.2.0"
@@ -22,8 +23,6 @@ jobs:
             @wemake.cx:https://registry.npmjs.org/|$NPM_TOKEN
 
       - name: Install dependencies
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun install --frozen-lockfile
 
       - name: Build
@@ -31,3 +30,5 @@ jobs:
 
       - name: Publish
         run: bun run publish-all
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Move NPM_TOKEN env var to publish step for security and add actions/checkout step to ensure proper repository checkout