### PR TITLE
chore: bump package versions to 0.4.1 across all MCP servers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "src/analogical-reasoning": {
       "name": "@wemake.cx/analogical-reasoning",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-analogical-reasoning": "dist/index.js",
       },
@@ -58,7 +58,7 @@
     },
     "src/bias-detection": {
       "name": "@wemake.cx/bias-detection",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-bias-detection": "dist/index.js",
       },
@@ -72,7 +72,7 @@
     },
     "src/collaborative-reasoning": {
       "name": "@wemake.cx/collaborative-reasoning",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-collaborative-reasoning": "dist/index.js",
       },
@@ -87,7 +87,7 @@
     },
     "src/constraint-solver": {
       "name": "@wemake.cx/constraint-solver",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-constraint-solver": "dist/index.js",
       },
@@ -102,7 +102,7 @@
     },
     "src/decision-framework": {
       "name": "@wemake.cx/decision-framework",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-decision-framework": "dist/index.js",
       },
@@ -117,7 +117,7 @@
     },
     "src/ethical-reasoning": {
       "name": "@wemake.cx/ethical-reasoning",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-ethical-reasoning": "dist/index.js",
       },
@@ -132,7 +132,7 @@
     },
     "src/focus-group": {
       "name": "@wemake.cx/focus-group",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-focus-group": "dist/index.js",
       },
@@ -147,7 +147,7 @@
     },
     "src/goal-tracker": {
       "name": "@wemake.cx/goal-tracker",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-goal-tracker": "dist/index.js",
       },
@@ -161,7 +161,7 @@
     },
     "src/memory": {
       "name": "@wemake.cx/memory",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-memory": "dist/index.js",
       },
@@ -190,7 +190,7 @@
     },
     "src/multimodal-synthesizer": {
       "name": "@wemake.cx/multimodal-synthesizer",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-multimodal-synthesizer": "dist/index.js",
       },
@@ -204,7 +204,7 @@
     },
     "src/narrative-planner": {
       "name": "@wemake.cx/narrative-planner",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-narrative-planner": "dist/index.js",
       },
@@ -218,7 +218,7 @@
     },
     "src/scientific-method": {
       "name": "@wemake.cx/scientific-method",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-scientific-method": "dist/index.js",
       },
@@ -233,7 +233,7 @@
     },
     "src/sequential-thinking": {
       "name": "@wemake.cx/sequential-thinking",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js",
       },
@@ -248,7 +248,7 @@
     },
     "src/structured-argumentation": {
       "name": "@wemake.cx/structured-argumentation",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-structured-argumentation": "dist/index.js",
       },
@@ -263,7 +263,7 @@
     },
     "src/transaction-manager": {
       "name": "@wemake.cx/transaction-manager",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-transaction-manager": "dist/index.js",
       },
@@ -281,7 +281,7 @@
     },
     "src/visual-reasoning": {
       "name": "@wemake.cx/visual-reasoning",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "mcp-server-visual-reasoning": "dist/index.js",
       },
@@ -516,7 +516,7 @@
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
-    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.1" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
@@ -684,7 +684,7 @@
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+    "asynckit": ["asynckit@0.4.1", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
@@ -840,13 +840,13 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.37.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.4.0", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.37.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig=="],
+    "eslint": ["eslint@9.37.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.4.1", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.37.0", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.1", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
-    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+    "espree": ["espree@10.4.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -902,7 +902,7 @@
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.1", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -1018,7 +1018,7 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
-    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.1" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lines-and-columns": ["lines-and-columns@2.0.3", "", {}, "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="],
 
@@ -1136,7 +1136,7 @@
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
-    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.1", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "ora": ["ora@5.3.0", "", { "dependencies": { "bl": "^4.0.3", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "log-symbols": "^4.0.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g=="],
 
@@ -1294,7 +1294,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+    "type-check": ["type-check@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/src/analogical-reasoning/package.json
+++ b/src/analogical-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/analogical-reasoning",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for structured analogical reasoning and domain mapping",
   "keywords": [
     "mcp",

--- a/src/analogical-reasoning/src/mcp/server.ts
+++ b/src/analogical-reasoning/src/mcp/server.ts
@@ -13,7 +13,7 @@ export class AnalogicalReasoningMcpServer {
     this.server = new Server(
       {
         name: "analogical-reasoning-server",
-        version: "0.4.0"
+        version: "0.4.1"
       },
       {
         capabilities: {

--- a/src/bias-detection/package.json
+++ b/src/bias-detection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/bias-detection",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for simple bias detection in text",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/bias-detection/src/mcp/server.ts
+++ b/src/bias-detection/src/mcp/server.ts
@@ -9,7 +9,7 @@ import { BiasDetectionInput } from "../core/types.js";
  * Creates and configures the MCP server.
  */
 export function createServer(): Server {
-  const server = new Server({ name: "bias-detection-server", version: "0.4.0" }, { capabilities: { tools: {} } });
+  const server = new Server({ name: "bias-detection-server", version: "0.4.1" }, { capabilities: { tools: {} } });
 
   const client = new BiasDetectionClient();
 

--- a/src/collaborative-reasoning/package.json
+++ b/src/collaborative-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/collaborative-reasoning",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for diagrammatic thinking and spatial representation",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/collaborative-reasoning/src/mcp/server.ts
+++ b/src/collaborative-reasoning/src/mcp/server.ts
@@ -10,7 +10,7 @@ export default function createServer(): Server {
   const server = new Server(
     {
       name: "collaborative-reasoning-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/constraint-solver/package.json
+++ b/src/constraint-solver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/constraint-solver",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for validating variable assignments against constraints",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/constraint-solver/src/index.ts
+++ b/src/constraint-solver/src/index.ts
@@ -13,7 +13,7 @@ export * from "./core/types.js";
  * Factory function that creates and configures a constraint solver MCP server instance.
  */
 export default function createServer(): Server {
-  const server = new Server({ name: "constraint-solver-server", version: "0.4.0" }, { capabilities: { tools: {} } });
+  const server = new Server({ name: "constraint-solver-server", version: "0.4.1" }, { capabilities: { tools: {} } });
   const constraintServer = new ConstraintMcpServer();
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [CONSTRAINT_SOLVER_TOOL] }));

--- a/src/decision-framework/package.json
+++ b/src/decision-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/decision-framework",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for diagrammatic thinking and spatial representation",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/decision-framework/src/mcp/server.ts
+++ b/src/decision-framework/src/mcp/server.ts
@@ -13,7 +13,7 @@ export class DecisionFrameworkMCPServer {
     this.server = new Server(
       {
         name: "decision-framework-server",
-        version: "0.4.0"
+        version: "0.4.1"
       },
       {
         capabilities: {

--- a/src/ethical-reasoning/package.json
+++ b/src/ethical-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/ethical-reasoning",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for structured ethical reasoning across multiple frameworks",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/ethical-reasoning/src/mcp/server.ts
+++ b/src/ethical-reasoning/src/mcp/server.ts
@@ -7,7 +7,7 @@ import { ETHICAL_REASONING_TOOL } from "./tools.js";
  * Creates and configures the MCP server instance.
  */
 export function createServer(): Server {
-  const server = new Server({ name: "ethical-reasoning-server", version: "0.4.0" }, { capabilities: { tools: {} } });
+  const server = new Server({ name: "ethical-reasoning-server", version: "0.4.1" }, { capabilities: { tools: {} } });
   const api = new EthicalReasoningAPI();
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [ETHICAL_REASONING_TOOL] }));

--- a/src/focus-group/package.json
+++ b/src/focus-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/focus-group",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for LLM focus groups to analyze and critique other MCP servers",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/focus-group/src/mcp/server.ts
+++ b/src/focus-group/src/mcp/server.ts
@@ -10,7 +10,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "focus-group-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/goal-tracker/package.json
+++ b/src/goal-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/goal-tracker",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "MCP server for tracking and completing simple goals",
   "license": "MIT",

--- a/src/goal-tracker/src/mcp/server.ts
+++ b/src/goal-tracker/src/mcp/server.ts
@@ -9,7 +9,7 @@ interface GoalInput {
 }
 
 export function createServer(): Server {
-  const version = process.env.PKG_VERSION ?? "0.4.0";
+  const version = process.env.PKG_VERSION ?? "0.4.1";
   const server = new Server({ name: "goal-tracker-server", version }, { capabilities: { tools: {} } });
   const tracker = new GoalTracker();
 

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/memory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for enabling memory for AI Agents through a knowledge graph",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/memory/src/mcp/server.ts
+++ b/src/memory/src/mcp/server.ts
@@ -21,7 +21,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "memory-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/multimodal-synthesizer/package.json
+++ b/src/multimodal-synthesizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/multimodal-synthesizer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for combining text and image descriptions",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/multimodal-synthesizer/src/mcp/index.ts
+++ b/src/multimodal-synthesizer/src/mcp/index.ts
@@ -6,7 +6,7 @@ import { MultimodalInput } from "../core/types.js";
 
 export function createServer(): Server {
   const server = new Server(
-    { name: "multimodal-synthesizer-server", version: "0.4.0" },
+    { name: "multimodal-synthesizer-server", version: "0.4.1" },
     { capabilities: { tools: {} } }
   );
   const synthesizer = new MultimodalSynthesizer();

--- a/src/narrative-planner/package.json
+++ b/src/narrative-planner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/narrative-planner",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server that creates simple narrative outlines",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/scientific-method/package.json
+++ b/src/scientific-method/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/scientific-method",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for hypothesis-driven experiments and scientific inquiry (scientific method)",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/scientific-method/src/mcp/index.ts
+++ b/src/scientific-method/src/mcp/index.ts
@@ -30,7 +30,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "scientific-method-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/sequential-thinking/package.json
+++ b/src/sequential-thinking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/sequential-thinking",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for sequential thinking and problem solving",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/sequential-thinking/src/mcp/server.ts
+++ b/src/sequential-thinking/src/mcp/server.ts
@@ -7,7 +7,7 @@ import { ThoughtData } from "../core/types.js";
 /**
  * Factory function that creates and configures a sequential thinking MCP server instance.
  *
- * This function initializes a Server with the name "sequential-thinking-server" and version "0.4.0",
+ * This function initializes a Server with the name "sequential-thinking-server" and version "0.4.1",
  * registers the SEQUENTIAL_THINKING_TOOL, and sets up request handlers.
  *
  * @returns A configured Server instance ready for MCP communication
@@ -16,7 +16,7 @@ export default function createServer(): Server {
   const server = new Server(
     {
       name: "sequential-thinking-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/structured-argumentation/package.json
+++ b/src/structured-argumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/structured-argumentation",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for diagrammatic thinking and spatial representation",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/structured-argumentation/src/mcp/index.ts
+++ b/src/structured-argumentation/src/mcp/index.ts
@@ -12,7 +12,7 @@ export function createServer(): Server {
   const server = new Server(
     {
       name: "structured-argumentation-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {

--- a/src/transaction-manager/package.json
+++ b/src/transaction-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/transaction-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP meta-server for managing stateful interactions via transaction tokens",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/transaction-manager/src/mcp/server.ts
+++ b/src/transaction-manager/src/mcp/server.ts
@@ -80,7 +80,7 @@ export async function handleTransactionCallback(args: TxnRequestArgs): Promise<C
 export function createServer(): McpServer {
   const mcpServer = new McpServer({
     name: "transaction-manager",
-    version: "0.4.0"
+    version: "0.4.1"
   });
 
   // Register the single tool

--- a/src/visual-reasoning/package.json
+++ b/src/visual-reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wemake.cx/visual-reasoning",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for diagrammatic thinking and spatial representation",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/visual-reasoning/src/mcp/server.ts
+++ b/src/visual-reasoning/src/mcp/server.ts
@@ -17,7 +17,7 @@ export default function createServer(): Server {
   const server = new Server(
     {
       name: "visual-reasoning-server",
-      version: "0.4.0"
+      version: "0.4.1"
     },
     {
       capabilities: {


### PR DESCRIPTION
Update version strings in package.json files and server initialization code for all MCP server packages from 0.4.0 to 0.4.1. Also update dependency versions in bun.lock to maintain consistency.